### PR TITLE
Explore `paused` mode only for TestCoroutineDispatcher.

### DIFF
--- a/kotlinx-coroutines-test/test/RunBlockingTestOrderTest.kt
+++ b/kotlinx-coroutines-test/test/RunBlockingTestOrderTest.kt
@@ -16,41 +16,44 @@ class RunBlockingTestOrderTest : TestBase() {
     val timeout = Timeout.seconds(1)
 
     @Test
-    fun testImmediateExecution() = runBlockingTest {
-        expect(1)
-        launch {
-            expect(2)
-        }
-        finish(3)
-    }
-
-    @Test
-    fun testImmediateNestedExecution() = runBlockingTest {
-        expect(1)
-        launch {
-            expect(2)
-            launch {
-                expect(3)
-            }
-        }
-        finish(4)
-    }
-
-    @Test
     fun testExecutionOrder() = runBlockingTest {
         expect(1)
         launch {
             expect(2)
+        }
+        runCurrent()
+        finish(3)
+    }
+
+    @Test
+    fun testNestedExecutionOrder() = runBlockingTest {
+        expect(1)
+        launch {
+            expect(2)
             launch {
                 expect(3)
+            }
+        }
+        runCurrent()
+        finish(4)
+    }
+
+    @Test
+    fun testComplexExecutionOrder() = runBlockingTest {
+        expect(1)
+        launch {
+            expect(2)
+            launch {
+                expect(4)
                 yield()
                 expect(6)
             }
-            expect(4)
+            expect(3)
             yield()
-            finish(7)
+            expect(5)
         }
-        expect(5)
+        runCurrent()
+        finish(7)
     }
 
     @Test
@@ -62,6 +65,7 @@ class RunBlockingTestOrderTest : TestBase() {
             expect(4)
             42
         }
+        runCurrent()
         expect(3)
         assertEquals(42, result.await())
         finish(5)

--- a/kotlinx-coroutines-test/test/obsolete/TestRunBlockingTest.kt
+++ b/kotlinx-coroutines-test/test/obsolete/TestRunBlockingTest.kt
@@ -29,41 +29,35 @@ class TestRunBlockingTest {
     @Test
     fun pauseDispatcher_disablesAutoAdvance_forCurrent() = runBlockingTest {
         var mutable = 0
-        pauseDispatcher {
-            launch {
-                mutable++
-            }
-            assertEquals(0, mutable)
-            runCurrent()
-            assertEquals(1, mutable)
+        launch {
+            mutable++
         }
+        assertEquals(0, mutable)
+        runCurrent()
+        assertEquals(1, mutable)
     }
 
     @Test
     fun pauseDispatcher_disablesAutoAdvance_forDelay() = runBlockingTest {
         var mutable = 0
-        pauseDispatcher {
-            launch {
-                mutable++
-                delay(SLOW)
-                mutable++
-            }
-            assertEquals(0, mutable)
-            runCurrent()
-            assertEquals(1, mutable)
-            advanceTimeBy(SLOW)
-            assertEquals(2, mutable)
+        launch {
+            mutable++
+            delay(SLOW)
+            mutable++
         }
+        assertEquals(0, mutable)
+        runCurrent()
+        assertEquals(1, mutable)
+        advanceTimeBy(SLOW)
+        assertEquals(2, mutable)
     }
 
     @Test
     fun pauseDispatcher_withDelay_resumesAfterPause() = runBlockingTest {
         var mutable = 0
         assertRunsFast {
-            pauseDispatcher {
-                delay(1_000)
-                mutable++
-            }
+            delay(1_000)
+            mutable++
         }
         assertEquals(1, mutable)
     }


### PR DESCRIPTION
Trying out removing the immediate mode API from TestCoroutineDispatcher and relying on runBlockingTest's event loop to pump the test lambda.

Overall, change seems like it might be heading the right direction with a large API surface reduction.

However, the automatic time advancement for the main test lambda is still present which has been fairly confusing to developers.

### Things that are better
- By removing immediate mode major issues around thread hopping and out-of
order execution in other event loops (e.g. Android Main thread) are resolved
- Developers that still desire Unconfined behavior can use Dispatchers.Unconfined. 

### Things that are neutral
- By exposing an API for waiting for new dispatches `DelayController.waitForDispatcherBusy(timeoutMillis)` developers can now interact with multithreading calls directly from `TestCoroutineDispatcher`. This API is not required for the runBlockingTest usage. This is important for some major parts of Android where thread checks are explict and must be satisfied. However, the API is less than obvious and it tends toward coupling tests with impl. details (possibly of transitive dependencies).

### Things that are worse
- The "launch and don't join" pattern will always require a call to `runCurrent` to execute the body of the coroutine.
- To write correct tests of functions that call `withContext` depends on if the dispatcher's are equal. If so, no dispatch happens and no additional API calls are required. If they are not equal, then a call to `waitForDispatcherBusy`/`runCurrent` is required when using `TestCoroutineDispatcher`. This is alleviated in `runBlockingTest` since the execution order of the `advanceTimeUntilIdle` will join the `withContext` coroutine before continuing the test.
- Because of the above, calling `waitForDispatcherBusy` after every function that calls `withContext` is not a safe invocation. It will  timeout and throw an exception in some invocations. This is a confusing API. How to cleanup?
- Dispatchers.Unconfined is incompatible with TestCoroutineScope.